### PR TITLE
change compliance and classification tags to required

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,20 +119,17 @@ Valid values:
 
 ### compliance
 
-Status: Recommended (if the resource falls under one of the defined
-security compliance groups)
+Status: Required
 
-For regulatory compliance, and will be (GDPR, PCI,
-HIPAA, etc.) as defined by policy.
+For regulatory compliance, and will be (GDPR, PCI, HIPAA, etc.) as
+defined by policy.
 
 ### classification
 
-Status: Recommended (if the resource has a label other than sensitive)
+Status: Required
 
-For data classification.  This is "sensitive" by default, and not needed
-to be specified unless it is different.  The value should be one of
-the options in our data classification standard (Public, Sensitive,
-Restricted, etc.)
+For data classification.  The value should be one of the options in our
+data classification standard (Public, Sensitive, Restricted, etc.)
 
 ### description
 


### PR DESCRIPTION
Based on feedback from Eric Berube in Teams:

> From a security perspective I definitely think it would be valuable to
> always know the nature/sensitivity of the data that a system stores
> or processes and would be worth requiring that tag. Functionally it
> also allows us to help identify assets related to different systems
> and requirements, which is a part of the NIST controls (unless
> there is another process for that that the teams are doing in those
> environments).
